### PR TITLE
Add --cmds option for commands to precede tex file

### DIFF
--- a/bin/pydflatex
+++ b/bin/pydflatex
@@ -44,6 +44,7 @@ add_option(parser, Runner, '-l', '--log-parsing', dest='typesetting', help='Only
 
 add_option(parser, Runner, '-t', '--typesetting', dest='log_parsing', help='Only typeset', action='store_false')
 
+add_option(parser, Typesetter, '--cmds', dest='cmds', help='Commands to precede tex file', type=str)
 
 parser.add_argument('tex_path', type=str, metavar='tex path', help='path to tex file')
 

--- a/pydflatex/typesetter.py
+++ b/pydflatex/typesetter.py
@@ -16,6 +16,7 @@ class Typesetter(Processor):
 
 	defaults = Processor.defaults.copy()
 	defaults.update({
+			'cmds': '',
 			'halt_on_errors': True,
 			'xetex': False,
 			})
@@ -48,8 +49,13 @@ class Typesetter(Processor):
 		now = datetime.datetime.now().strftime('%Y-%m-%d %H.%M.%S')
 		self.logger.message("\t[{now}] {engine} {file}".format(engine=self.engine(), file=full_path, now=now))
 		arguments = self.arguments()
-		# append file name
-		arguments.append(full_path)
+		if self.options['cmds']:
+			# append cmds and then \input file name
+			full_cmds = "{cmds}\input{{{file}}}".format(cmds=self.options['cmds'], file=full_path)
+			arguments.append(full_cmds)
+		else:
+			# append file name
+			arguments.append(full_path)
 		self.logger.debug("\n"+" ".join(arguments)+"\n")
 		output = subprocess.Popen(arguments, stdout=subprocess.PIPE).communicate()[0]
 		self.logger.message(output.splitlines()[0])


### PR DESCRIPTION
Similar to passing commands instead of a filename to pdflatex or
xelatex, but still allows for pydflatex to do any path magic and
output file finding it wants. Also allows for using commands with
latexmk, which normally only takes files (e.g. latexmk
-pdflatex="pydflatex --cmds '\def\webver{}').

e.g. Passing parameters to the tex file
Tex file:
    \ifdefined\webver
        web version
    \else
        normal version
    \fi

pydflatex --cmds '\def\webver{}' texfile
